### PR TITLE
Only store reference to proj/label in activeScope

### DIFF
--- a/app/views/pages/home.html.erb
+++ b/app/views/pages/home.html.erb
@@ -55,7 +55,7 @@
                         <div>
                             <task-list-switcher
                                 :tasks="$store.getters.tasksForActiveScope"
-                                :scope="$store.state.activeScope">
+                                :scope="$store.getters.activeScope">
                             </task-list-switcher>
                         </div>
                     </div>


### PR DESCRIPTION
When a user renames/deletes a project that is active, we need the `activeScope` property to react to the change. 